### PR TITLE
Add call to user count API

### DIFF
--- a/app/config/default.json.example
+++ b/app/config/default.json.example
@@ -18,7 +18,10 @@
             "availability": "ELB backend count",
             "default_system": "1234",
             "storage": "host=myhost&service=Check+disk+space",
-            "storage_pattern": "sitedata=(\\d+)MB"
+            "storage_pattern": "sitedata=(\\d+)MB",
+            "users_hostname": "moodle.example.com",
+            "users_protocol": "https:",
+            "users_token": "1234567890abcdef1234567890abcdef"
         }
     }
 }

--- a/app/index.js
+++ b/app/index.js
@@ -90,13 +90,7 @@ setup('get', '/wrs_over_time', require('./lib/get_wrs_over_time'));
 
 setup('get', '/deployments', require('./lib/get_deployments'));
 
-setup('get', '/users', function(req, res, next){
-    util.log(__filename, 'users()');
-    res.json({
-        result: 0
-    });
-    next && next(false);
-});
+setup('get', '/users', require('./lib/get_users'));
 
 setup('get', '/storage', require('./lib/get_storage'));
 

--- a/app/lib/get_users.js
+++ b/app/lib/get_users.js
@@ -35,7 +35,7 @@ module.exports = query.prepare(
         let req = http.request(options, (res) => {
             // This will only have a non-200 OK in pretty exceptional circumstances.
             if (res.statusCode !== 200) {
-                let e = 'users: ' + options.base_uri + ' => ' + res.statusCode;
+                let e = 'users: ' + options.users_hostname + ' => ' + res.statusCode;
                 util.log(__filename, e);
                 return error(e);
             }

--- a/app/lib/get_users.js
+++ b/app/lib/get_users.js
@@ -1,0 +1,67 @@
+var config= require('config'),
+    query = require('./query'),
+    http  = require('http'),
+    cache = require('./cache'),
+    util  = require('./util');
+
+module.exports = query.prepare(
+    'users',
+    'users',
+    null,
+    function(data, ctx, next){
+        let r = {
+            result: data
+        };
+        next(r);
+    },
+    (key, ctx, next, error) => {
+        if (!util.orgs[ctx.org] || !util.orgs[ctx.org].users_hostname || !util.orgs[ctx.org].users_token){
+            return error('No user lookup configured for ' + ctx.org);
+        }
+
+        const template = '/webservice/rest/server.php?wsfunction=local_user_count_api_count&' + 
+                'moodlewsrestformat=json&' +
+                'wstoken=USER_TOKEN&' + 
+                'duration=1&' +
+                'duration_unit=year';
+
+        const options = {
+            path: template
+                .replace('USER_TOKEN', util.orgs[ctx.org].users_token),
+            protocol: util.orgs[ctx.org].users_protocol ? util.orgs[ctx.org].users_protocol : 'https:',
+            hostname: util.orgs[ctx.org].users_hostname
+        }
+
+        let req = http.request(options, (res) => {
+            // This will only have a non-200 OK in pretty exceptional circumstances.
+            if (res.statusCode !== 200) {
+                let e = 'users: ' + options.base_uri + ' => ' + res.statusCode;
+                util.log(__filename, e);
+                return error(e);
+            }
+
+            let data = '';
+            res.on('data', chunk => { data += chunk });
+            res.on('end', () => {
+                let json = {};
+                try {
+                    json = JSON.parse(data);
+                    if (json.exception) {
+                        // Something went wrong with the WS request itself, eg bad token.
+                        throw json.message ? json.message : json.exception;
+                    }
+                    cache.put(key, json);
+                    util.log(__filename, 'users: ' + json.count);
+                } catch (ex) {
+                    let e = 'users: ' + ex;
+                    util.log(__filename, e);
+                    return error(e);
+                }
+                next(json.count);
+            });
+        });
+        req.on('error', error);
+        req.end();
+    },
+    60*60*1000 // cache TTL 1 hour
+);


### PR DESCRIPTION
Clients using this module will need:

* the user count API installed and enabled
* Web Services enabled, specifically REST
* a user token for the user count API will need to be obtained for a user (e.g. an administrative user) and put into the local config here

Once configured, the API will be called, response cached, and exported to the dashboard widget where KeenViz can display it, e.g. '42.1k users'.